### PR TITLE
Mock feature deployment by using comment

### DIFF
--- a/.github/workflows/comment-trigger-feature-deployment.yml
+++ b/.github/workflows/comment-trigger-feature-deployment.yml
@@ -1,7 +1,7 @@
 name: Comment Triggered Feature Branch Deployment
 
 on:
-  issue_comment:
+  pull_request_review_comment:
     types: [created]
     pattern: "%%FEATURE_BRANCH_DEPLOYMENT%%"
 

--- a/.github/workflows/comment-trigger-feature-deployment.yml
+++ b/.github/workflows/comment-trigger-feature-deployment.yml
@@ -1,7 +1,7 @@
 name: Comment Triggered Feature Branch Deployment
 
 on:
-  pull_request_review_comment:
+  issue_comment:
     types: [created]
     pattern: "%%FEATURE_BRANCH_DEPLOYMENT%%"
 

--- a/.github/workflows/comment-trigger-feature-deployment.yml
+++ b/.github/workflows/comment-trigger-feature-deployment.yml
@@ -47,7 +47,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const workflowId = "dispatch-deployment.yml";
-            console.log(JSON.stringify(context.issue, null, 4))
             const inputs = {
               targetRef: "${{ steps.get-branch.outputs.branch }}", // deployment use current PR base branch as target
               customField: "triggered by feature branch deployment comment",

--- a/.github/workflows/comment-trigger-feature-deployment.yml
+++ b/.github/workflows/comment-trigger-feature-deployment.yml
@@ -47,6 +47,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const workflowId = "dispatch-deployment.yml";
+            console.log(JSON.stringify(context.issue, null, 4))
             const inputs = {
               targetRef: "${{ steps.get-branch.outputs.branch }}", // deployment use current PR base branch as target
               customField: "triggered by feature branch deployment comment",

--- a/data.json
+++ b/data.json
@@ -1,5 +1,5 @@
 [
-  "main",
+  "feature",
   "branch",
   "data"
 ]


### PR DESCRIPTION
Simply use comment to trigger deployment

---

There are three ways for triggering mock feature branch deployment
1. (**Recommended**) Using pattern in comment to trigger a feature branch deployment
``` bash
# current PR feature branch deployment
FEATURE_BRANCH_DEPLOYMENT

# roll back as main branch deployment
MAIN_BRANCH_DEPLOYMENT
```

2. Using UI in `actions -> Mock Dispatch Deployment API`, then click `run workflow` and adjust inputs correspondingly.
<img width="1194" alt="Screenshot 2023-07-17 at 12 04 32 AM" src="https://github.com/vincecao/github-actions-dispatches/assets/17363908/474f6bc8-aff1-437b-8bbc-73b4dc7836a1">
<img width="353" alt="Screenshot 2023-07-17 at 12 05 16 AM" src="https://github.com/vincecao/github-actions-dispatches/assets/17363908/68340458-6558-4c7d-8cb2-da62517f1503">

3. Using Github rest api and call endpoint to call workflow dispatch, and adjust inputs correspondingly.
```
method:
  POST

url:
  https://api.github.com/repos/vincecao/github-actions-dispatches/actions/workflows/dispatch.yml/dispatches

headers:
  {
    "X-GitHub-Api-Version": "2022-11-28",
    "Accept": "application/vnd.github+json",
    "Authorization": "Bearer <TOKEN>" // workflows/repo PAT access
  }

body:
  {
    "ref": "main", // action located ref
    "inputs": {
        "targetRef": "feature", // dispatch input for target branch for mock feature deployment
        "customField": "test custom field value for feature branch", // sample action dispatch input
    }
  }
```

